### PR TITLE
docs: Add WordPress readme.txt for plugin directory compliance

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,26 +3,26 @@ Contributors: stbensonimoh
 Donate link: https://github.com/sponsors/stbensonimoh
 Tags: error-log, debug, logging, deduplication, monitoring
 Requires at least: 6.0
-Tested up to: 6.7
+Tested up to: 6.9
 Stable tag: 2.0.1
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-Zero-cost, high-performance log ingestion and de-duplication for WordPress.
+Zero-cost, high-performance log ingestion and deduplication for WordPress.
 
 == Description ==
 
-**WP Silent Witness** is a zero-cost, high-performance error log ingestion and de-duplication plugin for WordPress.
+**WP Silent Witness** is a zero-cost, high-performance error log ingestion and deduplication plugin for WordPress.
 
 It is designed for senior developers and consultants working in managed hosting environments (like WP Engine) where standard log files are often rotated, truncated, or difficult to access.
 
-Standard WordPress `debug.log` files are noisy and transient. Intermittent errors—the ones that happen once an hour or only during specific user actions—are easily lost.
+Standard WordPress 'debug.log' files are noisy and transient. Intermittent errors—the ones that happen once an hour or only during specific user actions—are easily lost.
 
 Silent Witness solves this by:
 
-1. **Ingesting from debug.log**: It reads and parses your existing WordPress debug log file (requires `WP_DEBUG_LOG` to be enabled), capturing PHP errors, warnings, and notices.
-2. **De-duplicating at the source**: It creates a unique hash for every error (Type + Message + File + Line). If an error happens 10,000 times, it occupies only **one row** in your database with an incrementing counter.
+1. **Ingesting from debug.log**: It reads and parses your existing WordPress debug log file (requires 'WP_DEBUG_LOG' to be enabled), capturing PHP errors, warnings, and notices.
+2. **Deduplicating at the source**: It creates a unique hash for every error (Type + Message + File + Line). If an error happens 10,000 times, it occupies only **one row** in your database with an incrementing counter.
 3. **Structured Export**: It provides a clean JSON export via WP-CLI, making it perfect for analysis by AI assistants or external tools.
 
 = Requirements =
@@ -35,40 +35,38 @@ Silent Witness solves this by:
 = Privacy & Security =
 
 * **Zero SaaS Cost**: No external subscriptions required.
-* **Fast Hashing**: Uses MD5 for signature generation and `ON DUPLICATE KEY UPDATE` for atomic, high-speed database writes.
+* **Fast Hashing**: Uses MD5 for signature generation and 'ON DUPLICATE KEY UPDATE' for atomic, high-speed database writes.
 * **Privacy**: Only stores essential error metadata (type, message, file path, line number, and deduplication counters). It does not log request context (URL, HTTP method, user ID), POST data, or cookies.
 
 == Installation ==
 
 = Method 1: Composer (Recommended for Developers) =
 
-`composer require stbensonimoh/wp-silent-witness`
+'composer require stbensonimoh/wp-silent-witness'
 
-Or add to your `composer.json`:
+Or add to your 'composer.json':
 
-```json
-{
-    "require": {
-        "stbensonimoh/wp-silent-witness": "^2.0"
+    {
+        "require": {
+            "stbensonimoh/wp-silent-witness": "^2.0"
+        }
     }
-}
-```
 
-**Note:** Composer will install to `wp-content/plugins/` by default. If using as an MU-plugin, move or symlink the package to `wp-content/mu-plugins/`.
+**Note:** Composer will install to 'wp-content/plugins/' by default. If using as an MU-plugin, move or symlink the package to 'wp-content/mu-plugins/'.
 
 = Method 2: Manual ZIP Download =
 
-1. Download the latest release from GitHub
+1. Download the latest release from GitHub: https://github.com/stbensonimoh/wp-silent-witness/releases
 2. Extract the ZIP file
-3. For **must-use plugin**: upload `wp-silent-witness.php` to `wp-content/mu-plugins/`
-4. For **standard plugin**: upload the entire `wp-silent-witness` folder to `wp-content/plugins/`, then activate **WP Silent Witness** from **Plugins → Installed Plugins** in the WordPress admin.
+3. For **must-use plugin**: upload 'wp-silent-witness.php' to 'wp-content/mu-plugins/'
+4. For **standard plugin**: upload the entire 'wp-silent-witness' folder to 'wp-content/plugins/', then activate **WP Silent Witness** from **Plugins → Installed Plugins** in the WordPress admin.
 
 = Prerequisites =
 
-You must enable WordPress debug logging by adding these to your `wp-config.php`:
+You must enable WordPress debug logging by adding these to your 'wp-config.php':
 
-`define('WP_DEBUG', true);`
-`define('WP_DEBUG_LOG', true);`
+    define('WP_DEBUG', true);
+    define('WP_DEBUG_LOG', true);
 
 == Frequently Asked Questions ==
 
@@ -82,21 +80,22 @@ Minimal. Each unique error occupies one row regardless of how many times it occu
 
 = Can I use this on a multisite installation? =
 
-Yes. The plugin uses `get_site_option()` and `update_site_option()` for network-wide consistency, and the logs table is shared across all sites.
+Yes. The plugin uses 'get_site_option()' and 'update_site_option()' for network-wide consistency, and the logs table is shared across all sites.
 
 = What do I need to enable for this to work? =
 
-You must enable WordPress debug logging by adding these to your `wp-config.php`:
-`define('WP_DEBUG', true);`
-`define('WP_DEBUG_LOG', true);`
+You must enable WordPress debug logging by adding these to your 'wp-config.php':
+
+    define('WP_DEBUG', true);
+    define('WP_DEBUG_LOG', true);
 
 = How do I view the logs? =
 
-Use WP-CLI: `wp silent-witness export` will output a clean JSON report of all de-duplicated errors.
+Use WP-CLI: 'wp silent-witness export' will output a clean JSON report of all deduplicated errors.
 
 = How do I clear the logs? =
 
-Use WP-CLI: `wp silent-witness clear` to wipe the records but keep the database structure. Use `wp silent-witness destroy --yes` to completely remove everything.
+Use WP-CLI: 'wp silent-witness clear' to wipe the records but keep the database structure. Use 'wp silent-witness destroy --yes' to completely remove everything.
 
 == Screenshots ==
 


### PR DESCRIPTION
## Summary

This PR adds the required "readme.txt" file for WordPress.org Plugin Directory compliance, as outlined in issue #16.

## Changes

- Added "readme.txt" following the [WordPress plugin readme file standard](https://wordpress.org/plugins/readme.txt)
- Included all required headers: Plugin Name, Contributors, Tags, Requires at least, Tested up to, Stable tag, License
- Added comprehensive sections:
  - Short description (150 characters max)
  - Long description with feature highlights
  - Installation instructions (Composer and manual methods)
  - FAQ section addressing common questions
  - Screenshots placeholder section
  - Changelog with version history
  - Upgrade notices

## Why This Matters

The WordPress.org Plugin Directory **requires** a readme.txt file for:
- Proper plugin display on wordpress.org/plugins/
- Installation instructions for users
- FAQ and changelog visibility
- Plugin discovery and search optimization

## References

- Closes #16
- [WordPress Plugin Developer Information](https://wordpress.org/plugins/developers/)
- [How Your readme.txt Works](https://developer.wordpress.org/plugins/wordpress-org/how-your-readme-txt-works/)

## Testing

- [ ] Verify readme.txt passes the [official readme validator](https://wordpress.org/plugins/developers/readme-validator/)
- [ ] Check that all plugin metadata matches the main PHP file
- [ ] Confirm short description is under 150 characters

---

**Type:** Documentation  
**Breaking Change:** No